### PR TITLE
Don't delete empty files if they're already in SVN

### DIFF
--- a/web/Weblate-server.qmd
+++ b/web/Weblate-server.qmd
@@ -190,7 +190,7 @@ The basic idea is to compare the Weblate repo (which copies the R subversion rep
     po_summary <- merge(weblate_summary, svn_summary, by = "filename", all = TRUE, suffixes = c("_weblate", "_svn"))
     po_summary[, package := basename(dirname(dirname(filename)))]
     # Drop empty & record files
-    po_summary[n_translated_weblate == 0, {
+    po_summary[n_translated_weblate == 0 & is.na(n_translated_svn), { # NB: keep empty files if they're already in SVN, hence is.na() check
        log_info('Dropping {.N} empty files:')
        .SD[, by = package, {
           log_level(INFO, 'From package {blue(.BY$package)}:')


### PR DESCRIPTION
Following e-mail discussion. `git` logic for the most recent patch managed to mark a Hungarian translation file (which doesn't exist yet on SVN) as 'branched' from the Albanian file (which does exist, but only has fuzzy translations & hence looks empty to the old logic).

Therefore we need to be careful not to prune from the Weblate mirror those empty .po files which correspond to empty SVN files.

As to how it can happen that an empty file winds up in SVN, this appears to be related to #6 -- on initial check-in, the sq.po file appears to have been generated from R-base.pot, not R.pot:

https://github.com/r-devel/r-svn/blob/c23093fd5f0787d08e4c51ddfa4b13f6e6bb476d/src/library/base/po/sq.po

So all of those msgstr, having never been found in R.pot to begin with, would be marked `fuzzy` on next update.

PS I quickly glanced at R-sq.po, and I think the translations in sq.po have not been lost, having been given in duplicate to begin with.