### PR TITLE
add French-specific-translations.qmd to the menu (#54)

### DIFF
--- a/web/Conventions_for_Languages/Brazilian‐Portugese-specific-translations.qmd
+++ b/web/Conventions_for_Languages/Brazilian‐Portugese-specific-translations.qmd
@@ -89,8 +89,7 @@ if its use is not strictly correct.
 
 Unlike Portuguese, English does not specify grammatical gender. We will try to follow the [Manual for Non Sexist Use of 
 Language (in 
-Portuguese)](https://edisciplinas.usp.br/pluginfile.php/3034366/mod_resource/content/1/Manual%20para%20uso%20n%C3%A3o%
-20sexista%20da%20linguagem.pdf) in translations as much as we can, but unfortunately that is not always possible.
+Portuguese)](https://edisciplinas.usp.br/pluginfile.php/3034366/mod_resource/content/1/Manual%20para%20uso%20n%C3%A3o%20sexista%20da%20linguagem.pdf) in translations as much as we can, but unfortunately that is not always possible.
 
 Grammatical gender of arguments, acronyms and other nouns can usually be inferred by context. In the example below, we 
 translate "_DLL_" as "a biblioteca de vínculo dinâmico" (dynamic-link library).

--- a/web/Conventions_for_Languages/French-specific-translations.qmd
+++ b/web/Conventions_for_Languages/French-specific-translations.qmd
@@ -18,7 +18,7 @@ Pour aider le processus de traduction, veuillez :
 
 1. Vous inscrire au [Slack des contributeurs de R](https://contributor.r-project.org/slack) et présentez-vous sur le canal 
 `#core-translations`
-1. Lire la section [Ressources](#Ressources) de ce document, car la traduction suit certaines conventions à respecter
+1. Lire la section [Ressources](#ressources) de ce document, car la traduction suit certaines conventions à respecter
 1. Créer un compte sur [Weblate](https://translate.rx.studio/) (maintenu actuellement par [@daroczig](https://twitter.com/daroczig))
 1. Lister chaque [composant](https://translate.rx.studio/languages/fr/r-project/) en français
 1. Choisir un composant qui n'est pas traduit à 100% (comme par exemple le [package utils](https://translate.rx.studio/projects/r-project/utils-r/fr/))

--- a/web/Conventions_for_Languages/French-specific-translations.qmd
+++ b/web/Conventions_for_Languages/French-specific-translations.qmd
@@ -1,36 +1,29 @@
 ---
-title: "Brazilian Portuguese"
+title: "French"
 ---
 
-_This repository is a hub for all people who want to help translate R into Brazilian Portuguese. This README is in 
+_This repository is a hub for all people who want to help translate R into French. This README is in 
 English, but you can reach out to other translators on the R Contributors Slack if you need any additional information 
 about the project._
 
-## About
+## A propos
 
-The goal of the _pt-bR_ project is to bring together all people interested in helping translate the [R 
-language](https://en.wikipedia.org/wiki/R_(programming_language)) into Brazilian Portuguese 🇧🇷. If you use R a lot, we 
-need your help!
+Le but du projet _fr_ est de rassembler chaque personne qui souhaite aider à la traductions du [langage R](https://en.wikipedia.org/wiki/R_(programming_language)) en français  🇫🇷. Si vous utilisez R souvent, nous avons besoin de votre aide !
 
-Unlike other languages, R tries to display every message in the same language as the computer it's running on. In 
-principle, this reduces R's barrier to entry; warnings and errors are very common in code written by beginners, so it's 
-essential that these messages are as clear as possible.
+A la différence des autres langages de programmation, R essaie d'afficher chaque message dans la même langue que votre ordinateur. En principe cela réduit la barrière de la langue pour aborder R. Les erreurs et les avertissements sont très communs dans le code écrit par les débutants, il est donc essentiel que ces messages soient les plus clairs possibles.
 
-## How to contribute
+## Comment contribuer
 
-To help in the translation process, you need to:
+Pour aider le processus de traduction, veuillez :
 
-1. Sign up to the [R Contributors Slack](https://contributor.r-project.org/slack) and introduce yourself in the 
-`#core-translations` channel;
-1. Read the [Resources](#resources) section of this document, because the translation has some conventions that should 
-be followed;
-1. Create an account on [Weblate](https://translate.rx.studio/) (currently maintained by 
-[@daroczig](https://twitter.com/daroczig));
-1. List every Brazilian Portuguese [component](https://translate.rx.studio/languages/pt_BR/r-project/);
-1. Choose a component that's not 100% translated (like, for example, the [utils 
-package](https://translate.rx.studio/projects/r-project/utils-r/pt_BR/));
-1. Click **Unfinished strings** to list all messages that haven't been translated and
-1. Start!
+1. Vous inscrire au [Slack des contributeurs de R](https://contributor.r-project.org/slack) et présentez-vous sur le canal 
+`#core-translations`
+1. Lire la section [Ressources](#resources) de ce document, car la traduction suit certaines conventions à respecter
+1. Créer un compte sur [Weblate](https://translate.rx.studio/) (maintenu actuellement par [@daroczig](https://twitter.com/daroczig))
+1. Lister chaque [composant](https://translate.rx.studio/languages/fr/r-project/) en français
+1. Choisir un composant qui n'est pas traduit à 100% (comme par exemple le [package utils](https://translate.rx.studio/projects/r-project/utils-r/fr/))
+1. Cliquer sur **Unfinished strings** pour lister tous les messages non traduits et
+1. Commencez !
 
 ## Style
 

--- a/web/Conventions_for_Languages/French-specific-translations.qmd
+++ b/web/Conventions_for_Languages/French-specific-translations.qmd
@@ -8,7 +8,7 @@ about the project._
 
 ## A propos
 
-Le but du projet _fr_ est de rassembler chaque personne qui souhaite aider à la traductions du [langage R](https://en.wikipedia.org/wiki/R_(programming_language)) en français  🇫🇷. Si vous utilisez R souvent, nous avons besoin de votre aide !
+Le but du projet _fr_ est de rassembler chaque personne qui souhaite aider à la traductions du [langage R](https://en.wikipedia.org/wiki/R_(programming_language)) en français 🇫🇷. Si vous utilisez R souvent, nous avons besoin de votre aide !
 
 A la différence des autres langages de programmation, R essaie d'afficher chaque message dans la même langue que votre ordinateur. En principe cela réduit la barrière de la langue pour aborder R. Les erreurs et les avertissements sont très communs dans le code écrit par les débutants, il est donc essentiel que ces messages soient les plus clairs possibles.
 
@@ -27,117 +27,101 @@ Pour aider le processus de traduction, veuillez :
 
 ## Style
 
-R is a programming language that's almost 30 years old and, therefore, its messages were written by many people with 
-very different writing styles. We should always follow Portuguese's grammar and orthography, including the new [Spelling 
-Reform](https://www2.senado.leg.br/bdsf/bitstream/handle/id/508145/000997415.pdf), but we also want to preserve the 
-original language as much as possible.
+R est un langage de programmation qui a presque 30 ans et c'est pourquoi les messages se trouvent écrits par plusieurs personnes dont le style est différent.
+Nous devons toujours suivre ici la grammaire et l'orthographe française, en appliquant les nouvelles réformes correspondantes, mais nous voulons préserver la langue initiale le plus possible.
 
-In English it is possible to omit many connectors without changing the meaning. The Italian and French teams usually 
-restore these connectors when the alternative wouldn't sound as natural.
+En anglais, vous pouvez omettre les coordinations sans changer la signification.
+Nous les ajoutons habituellement quand la phrase ne semble pas naturelle.
 
 > _Maybe package installed with version of R newer than %s ?_
 
-> Talvez o pacote tenha sido instalado com uma versão do R mais recente que %s ?
+> Le package est peut-être installé avec une version de R plus récente que %s ?
 
-We also don't translate anything that is a technical term from R like, for example, function names, objects and 
-arguments (usually between quotes).
+Les termes techniques de R ne sont pas à traduire, comme par exemple le nom des fonctions, des objets et des argument (habituellement entre apostrophes).
 
 > _'MARGIN' does not match dim(X)_
 
-> 'MARGIN' não corresponde a dim(X)
+> 'MARGIN' ne correspond pas à dim(X)
 
-In exceptional situations, a function can be used as a verb. Following the French and Italian teams, the only solution 
-is to completely reconstruct the sentence.
+Dans les cas particuliers, une fonction peut être utilisée comme verbe. Nous adoptons la solution de reconstruire la phrase.
 
 > _cannot xtfrm data frames_
 
-> impossível utilizar xtfrm em um data frame
+> xtfrm ne peut être utilisé avec les data frame
 
+### Formatage
 
-### Formatting
+L'utilisation des espaces et des paragraphes en français est règlementée par la typographie.
+Les textes R, néanmoins ont des contraintes d'espace et de format qui ne sont pas évidentes à traduire.
 
-The use of spaces and paragraphs in Portuguese is standardised and well established. R texts, however, have space and 
-formatting limitations that are not always obvious when translating.
-
-Most R messages have some kind of reference to the code that generated them. This happens through [format 
-specifiers](https://cplusplus.com/reference/cstdio/printf/) and we need to keep them in the same order as they appear in 
-the reference text.
+La plupart des messages R portent sous une certaine forme la référence au code qui les a produits.
+Ceci ce fait à l'aide des [spécifieurs de format](https://cplusplus.com/reference/cstdio/printf/) et ils doivent être dans le même ordre dans le texte de référence.
 
 > _%s and %s must have the same length_
 
-> %s e %s devem ter o mesmo comprimento
+> %s et %s doivent avoir la même longueur
 
-If it's not possible to keep the same order, you need to specify the index of the desired substitution with `%n$<fmt>` 
-(e.g. `%1$s`, `%2$s`, and so on).
+S'il n'est pas possible de conserver le même ordre, vous devez utiliser l'indice de la substitution choisie avec `%n$<fmt>` 
+(par exemple `%1$s`, `%2$s`, etc.).
 
-Messages can also have special characters such as single quotes (`'`), double quotes (`"`), tabs (`\t`) and new lines 
-(`\n`), as well as extra spaces in strange places. To maintain a standard, we don't change this type of formatting even 
-if its use is not strictly correct.
+Les messages peuvent aussi comporter des caractères spéciaux tels que des apostrophes simples (`'`), des guillemets (`"`), des tabulations (`\t`) et des passages à la ligne 
+(`\n`), tout comme des espaces supplémentaires à des endroits particuliers.
+Pour maintenir un standard, nous ne modifions pas ce type de mise en forme même si son utilisation ne nous semble pas correcte.
 
 > _Conflicts attaching package %s:<br>%s_
 
-> Conflitos ao anexar pacote %s:<br>%s
+> Conflicts pour attacher le package %s :<br>%s
 
-### Gender
+### Genre
 
-Unlike Portuguese, English does not specify grammatical gender. We will try to follow the [Manual for Non Sexist Use of 
-Language (in 
-Portuguese)](https://edisciplinas.usp.br/pluginfile.php/3034366/mod_resource/content/1/Manual%20para%20uso%20n%C3%A3o%
-20sexista%20da%20linguagem.pdf) in translations as much as we can, but unfortunately that is not always possible.
+A la différence du français, l'anglais ne spécifie pas le genre grammatical.
+Nous utiliserons la terminologie utilisée habituellement dans la littérature technique française.
 
-Grammatical gender of arguments, acronyms and other nouns can usually be inferred by context. In the example below, we 
-translate "_DLL_" as "a biblioteca de vínculo dinâmico" (dynamic-link library).
+Le genre grammatical des arguments, des acronymes et autres noms peut habituellement être déduit du contexte. 
+Dans l'exemple ci-dessous, nous interprétons "_DLL_" par "bibliothèque de liens dynamiques" (dynamic-link library).
 
 > _DLL %s was not loaded_
 
-> DLL %s não foi carregada
+> DLL %s ne s'est pas chargée
 
-In the following example, although "_scale_" is a feminine noun in Portuguese, the masculine is used because it is 
-replacing "_argument_", "o argumento", which is a masculine noun.
+Dans l'exemple suivant, bien que "_scale_" soit féminin en français, le masculin est utilisé car il remplace "_argument_" qui est un nom masculin.
 
 > _'scale' should be numeric or NULL_
 
-> 'scale' deve ser numérico ou NULL
+> 'scale' doit être numérique ou NULL
 
-In certain situations, we can simply ignore genders. In the following expression, we could translate "_author_" to 
-"autor(a)", but there are alternatives that allow us to completely omit it.
+Dans certains cas, les genres peuvent simplement être ignorés. Dans les expressions suivantes il est possible de traduire "_author_" par "auteur(e)", mais il existe des tournures permettant souvent de s'en passer.
 
 > _Authors@R field gives no person with name and author role_
 
-> Campo Authors@R não fornece nenhuma pessoa com nome e papel 'author'
+> Le champ Authors@R ne désigne aucune personne avec son rôle
 
-In rare cases, the messeges references who doing the programming. In these cases, the best we can do without 
-jeopardising comprehension or overly increasing the length of the sentence is to use "o(a)".
+Dans certains cas plus rares, les messages référencent la personne qui programme. 
+Dans ce cas, si cela est expressément demandé, vous pourrez utiliser "o(a)" pour rester lisible et ne pas augmenter la taille de la phrase.
 
 > _Not enough arguments passed to user macro '%s'_
 
-> Não foram passados argumentos suficientes para a macro '%s' do(a) usuário(a)
+> Pas assez d'arguments passés à la macro '%s' de l'utilisateur
 
-It's important to note that this strategy is not adopted by the French and Italian teams, who prefer to simply use the 
-masculine term "usuário". Unless there is some guideline discouraging resources such as "o(a)", we believe that our 
-standard is preferable.
+En français on utilisera le terme masculin "utilisateur" qui fait référence à la fonction plutôt qu'au genre.
 
-## Resources
+## Ressources
 
-This is a living document that lists some common problems that come up when translating R to Brazilian Portuguese. Every 
-suggestion here is open to debate and, if you disagree about something, simply create a new topic in the 
-[discussions](https://github.com/r-devel/translations/discussions) tab.
+Ce document est vivant et liste le problèmes communs à propos de la traduction de R en français. 
+Chaque suggestion ici est ouverte au débat et si vous êtes en désaccord avec un élément vous pouvez le signaler en créant simplement un nouveau sujet dans l'onglet [discussions](https://github.com/r-devel/translations/discussions) .
 
-- [Weblate documentation on translation workflow](https://docs.weblate.org/en/latest/workflows.html) - [Translation 
-dashboard](https://contributor.r-project.org/translations-dashboard/)
+- [Documentation Weblate sur le flux du travail de traduction](https://docs.weblate.org/en/latest/workflows.html) - [Tableau de bord des traductions](https://contributor.r-project.org/translations-dashboard/)
 
-### Glossary
+### Glossaire
 
-Here we have put together some terms that appear repeatedly in R messages and which can be difficult to translate. If 
-you have problems with a word that is not in the table below, look up the translation on 
-[Linguee](https://www.linguee.com) or Wikipedia and let us know so we can include it in this section.
+Nous avons regroupé ici les termes qui apparaissent souvent dans les messages R et pouvant représenter des difficultés de traduction.
+Si un mot vous pose problème et qu'il ne se trouve pas dans le tableau ci-dessous, recherchez la traduction avec [Linguee](https://www.linguee.com) ou Wikipedia et indiquez-nous la pour que nous puissions l'inclure dans cette section.
 
-We have tried to use the most common versions of each term, but it's not always possible to keep a precise account. For 
-example, if you are searching for "_caching_", the corresponding entry is "_cache_". The same word can also have several 
-functions, such as "_replacement_", which simultaneously means "substituto" and "substituição".
+Nous avons essayé d'utiliser les versions les plus communes de chaque terme, mais il n'est pas toujours possible de tenir une liste exhaustive.
+Par exemple si vous cherchez "_caching_", l'entrée correspondante est "_cache_". 
+Le même mot peut avoir aussi plusieurs fonctions telles que "_replacement_", qui signifie à la fois "substitution" et "substitué".
 
-Finally, we have chosen to keep some of the terms in English, as their translations are not widely used, but this 
-perception is purely subjective; the words marked with an asterisk \* are those that we ourselves are questioning.
+Certain mots de par leur usage conservent leur terme anglais puisque leur traduction est faiblement utilisée, mais ce n'est que subjectif; les mots affectés d'un astérisque \* sont ceux sur lesquels un consensus doit statuer.
 
 | Inglês               | Português                                    |
 |:---------------------|:---------------------------------------------|

--- a/web/Conventions_for_Languages/French-specific-translations.qmd
+++ b/web/Conventions_for_Languages/French-specific-translations.qmd
@@ -1,0 +1,313 @@
+---
+title: "Brazilian Portuguese"
+---
+
+_This repository is a hub for all people who want to help translate R into Brazilian Portuguese. This README is in 
+English, but you can reach out to other translators on the R Contributors Slack if you need any additional information 
+about the project._
+
+## About
+
+The goal of the _pt-bR_ project is to bring together all people interested in helping translate the [R 
+language](https://en.wikipedia.org/wiki/R_(programming_language)) into Brazilian Portuguese 🇧🇷. If you use R a lot, we 
+need your help!
+
+Unlike other languages, R tries to display every message in the same language as the computer it's running on. In 
+principle, this reduces R's barrier to entry; warnings and errors are very common in code written by beginners, so it's 
+essential that these messages are as clear as possible.
+
+## How to contribute
+
+To help in the translation process, you need to:
+
+1. Sign up to the [R Contributors Slack](https://contributor.r-project.org/slack) and introduce yourself in the 
+`#core-translations` channel;
+1. Read the [Resources](#resources) section of this document, because the translation has some conventions that should 
+be followed;
+1. Create an account on [Weblate](https://translate.rx.studio/) (currently maintained by 
+[@daroczig](https://twitter.com/daroczig));
+1. List every Brazilian Portuguese [component](https://translate.rx.studio/languages/pt_BR/r-project/);
+1. Choose a component that's not 100% translated (like, for example, the [utils 
+package](https://translate.rx.studio/projects/r-project/utils-r/pt_BR/));
+1. Click **Unfinished strings** to list all messages that haven't been translated and
+1. Start!
+
+## Style
+
+R is a programming language that's almost 30 years old and, therefore, its messages were written by many people with 
+very different writing styles. We should always follow Portuguese's grammar and orthography, including the new [Spelling 
+Reform](https://www2.senado.leg.br/bdsf/bitstream/handle/id/508145/000997415.pdf), but we also want to preserve the 
+original language as much as possible.
+
+In English it is possible to omit many connectors without changing the meaning. The Italian and French teams usually 
+restore these connectors when the alternative wouldn't sound as natural.
+
+> _Maybe package installed with version of R newer than %s ?_
+
+> Talvez o pacote tenha sido instalado com uma versão do R mais recente que %s ?
+
+We also don't translate anything that is a technical term from R like, for example, function names, objects and 
+arguments (usually between quotes).
+
+> _'MARGIN' does not match dim(X)_
+
+> 'MARGIN' não corresponde a dim(X)
+
+In exceptional situations, a function can be used as a verb. Following the French and Italian teams, the only solution 
+is to completely reconstruct the sentence.
+
+> _cannot xtfrm data frames_
+
+> impossível utilizar xtfrm em um data frame
+
+
+### Formatting
+
+The use of spaces and paragraphs in Portuguese is standardised and well established. R texts, however, have space and 
+formatting limitations that are not always obvious when translating.
+
+Most R messages have some kind of reference to the code that generated them. This happens through [format 
+specifiers](https://cplusplus.com/reference/cstdio/printf/) and we need to keep them in the same order as they appear in 
+the reference text.
+
+> _%s and %s must have the same length_
+
+> %s e %s devem ter o mesmo comprimento
+
+If it's not possible to keep the same order, you need to specify the index of the desired substitution with `%n$<fmt>` 
+(e.g. `%1$s`, `%2$s`, and so on).
+
+Messages can also have special characters such as single quotes (`'`), double quotes (`"`), tabs (`\t`) and new lines 
+(`\n`), as well as extra spaces in strange places. To maintain a standard, we don't change this type of formatting even 
+if its use is not strictly correct.
+
+> _Conflicts attaching package %s:<br>%s_
+
+> Conflitos ao anexar pacote %s:<br>%s
+
+### Gender
+
+Unlike Portuguese, English does not specify grammatical gender. We will try to follow the [Manual for Non Sexist Use of 
+Language (in 
+Portuguese)](https://edisciplinas.usp.br/pluginfile.php/3034366/mod_resource/content/1/Manual%20para%20uso%20n%C3%A3o%
+20sexista%20da%20linguagem.pdf) in translations as much as we can, but unfortunately that is not always possible.
+
+Grammatical gender of arguments, acronyms and other nouns can usually be inferred by context. In the example below, we 
+translate "_DLL_" as "a biblioteca de vínculo dinâmico" (dynamic-link library).
+
+> _DLL %s was not loaded_
+
+> DLL %s não foi carregada
+
+In the following example, although "_scale_" is a feminine noun in Portuguese, the masculine is used because it is 
+replacing "_argument_", "o argumento", which is a masculine noun.
+
+> _'scale' should be numeric or NULL_
+
+> 'scale' deve ser numérico ou NULL
+
+In certain situations, we can simply ignore genders. In the following expression, we could translate "_author_" to 
+"autor(a)", but there are alternatives that allow us to completely omit it.
+
+> _Authors@R field gives no person with name and author role_
+
+> Campo Authors@R não fornece nenhuma pessoa com nome e papel 'author'
+
+In rare cases, the messeges references who doing the programming. In these cases, the best we can do without 
+jeopardising comprehension or overly increasing the length of the sentence is to use "o(a)".
+
+> _Not enough arguments passed to user macro '%s'_
+
+> Não foram passados argumentos suficientes para a macro '%s' do(a) usuário(a)
+
+It's important to note that this strategy is not adopted by the French and Italian teams, who prefer to simply use the 
+masculine term "usuário". Unless there is some guideline discouraging resources such as "o(a)", we believe that our 
+standard is preferable.
+
+## Resources
+
+This is a living document that lists some common problems that come up when translating R to Brazilian Portuguese. Every 
+suggestion here is open to debate and, if you disagree about something, simply create a new topic in the 
+[discussions](https://github.com/r-devel/translations/discussions) tab.
+
+- [Weblate documentation on translation workflow](https://docs.weblate.org/en/latest/workflows.html) - [Translation 
+dashboard](https://contributor.r-project.org/translations-dashboard/)
+
+### Glossary
+
+Here we have put together some terms that appear repeatedly in R messages and which can be difficult to translate. If 
+you have problems with a word that is not in the table below, look up the translation on 
+[Linguee](https://www.linguee.com) or Wikipedia and let us know so we can include it in this section.
+
+We have tried to use the most common versions of each term, but it's not always possible to keep a precise account. For 
+example, if you are searching for "_caching_", the corresponding entry is "_cache_". The same word can also have several 
+functions, such as "_replacement_", which simultaneously means "substituto" and "substituição".
+
+Finally, we have chosen to keep some of the terms in English, as their translations are not widely used, but this 
+perception is purely subjective; the words marked with an asterisk \* are those that we ourselves are questioning.
+
+| Inglês               | Português                                    |
+|:---------------------|:---------------------------------------------|
+| abort                | interromper                                  |
+| alias                | alias\*                                      |
+| allocate             | alocar                                       |
+| argument             | argumento                                    |
+| array                | array                                        |
+| assign               | atribuir                                     |
+| attach               | anexar                                       |
+| attribute            | atributo                                     |
+| backslash            | barra invertida                              |
+| bind                 | associar / vincular                          |
+| bitmap               | bitmap                                       |
+| boxplot              | boxplot                                      |
+| break                | limite de categoria (para histogramas)       |
+| browser              | navegador                                    |
+| build                | compilar                                     |
+| bytecode             | bytecode                                     |
+| cache                | cachear                                      |
+| call                 | chamar                                       |
+| callback             | callback                                     |
+| character string     | string de caracteres\*                       |
+| check                | verificar                                    |
+| chunk                | bloco (de código)\*                          |
+| closure              | closure                                      |
+| codoc                | codoc (da função do R)                       |
+| coerce               | fazer coerção                                |
+| colortype            | colortype                                    |
+| console              | console                                      |
+| data frame           | data frame                                   |
+| database             | base de dados                                |
+| dataset              | conjunto de dados                            |
+| debug                | depurar\*                                    |
+| defunct              | extinto                                      |
+| deparse              | deparse                                      |
+| deprecated           | obsoleto                                     |
+| detach               | detach\*                                     |
+| device               | dispositivo                                  |
+| dispatch             | despachar                                    |
+| documentation object | objeto de documentação\*                     |
+| download             | baixar                                       |
+| driver               | driver                                       |
+| drop                 | descartar                                    |
+| encoding             | codificação                                  |
+| entry                | registro / campo                             |
+| environment          | ambiente                                     |
+| evaluate             | avaliar (por exemplo, `eval()`)\*            |
+| factor               | fator                                        |
+| fifo                 | fifo (de _first in, first out_)              |
+| file pointer         | ponteiro de arquivo\*                        |
+| file stream          | stream de arquivo                            |
+| filename             | nome do arquivo                              |
+| fit                  | ajustar                                      |
+| flag                 | flag                                         |
+| flush                | esvaziar                                     |
+| frame                | quadro (para _stack_) / escopo (para _call_) |
+| handle               | gerenciar                                    |
+| hard-coded           | hard-coded\*                                 |
+| history              | histórico                                    |
+| implement            | implementar                                  |
+| incoming checks      | verificações de recebimento\*                |
+| index                | índice                                       |
+| invalid              | inválido                                     |
+| IO                   | IO                                           |
+| label                | rótulo                                       |
+| lag                  | defasagem                                    |
+| layout               | layout\*                                     |
+| lazy loading         | lazy loading\*                               |
+| lazydata             | lazydata                                     |
+| leading minor        | submatriz\*                                  |
+| length               | comprimento                                  |
+| library              | biblioteca                                   |
+| link                 | link                                         |
+| locale               | locale                                       |
+| locator              | localizador                                  |
+| locking              | travamento\*                                 |
+| logical              | lógico (ao invés de booleano)                |
+| macro                | macro                                        |
+| magic number         | número mágico                                |
+| match                | corresponder                                 |
+| metafile             | metafile                                     |
+| mirror               | espelho (por exemplo, do CRAN)               |
+| mismatch             | incompatível                                 |
+| missing              | ausente                                      |
+| modulus              | módulo                                       |
+| multibyte            | multibyte                                    |
+| namespace            | namespace\*                                  |
+| non-interactively    | de forma não interativa                      |
+| non-numeric type     | tipo não numérico                            |
+| numeric-alike        | numérico ou similar\*                        |
+| offending            | problemático                                 |
+| offset               | deslocar / compensar (depende do contexto)   |
+| opcode               | opcode                                       |
+| outlier              | outlier\*                                    |
+| overflow             | overflow                                     |
+| override             | sobrescrever                                 |
+| package              | pacote                                       |
+| pager                | visualizador\*                               |
+| pair list            | lista pareada                                |
+| parse                | analisar\*                                   |
+| path                 | caminho                                      |
+| pipe                 | pipe                                         |
+| pixmap               | pixmap                                       |
+| platform             | plataforma                                   |
+| polyline             | polyline                                     |
+| port                 | porta (por exemplo, 8080)                    |
+| portable             | portável                                     |
+| profiling            | análise de desempenho                        |
+| profile              | perfil (substantivo), perfilar (verbo)       |
+| promise              | promessa                                     |
+| prompt               | prompt                                       |
+| proxy                | proxy                                        |
+| push back            | voltar atrás                                 |
+| quote symbol         | símbolo de citação                           |
+| range                | intervalo / limite (depende do contexto)     |
+| raw                  | raw (para o tipo de dado)                    |
+| redraw               | redesenhar                                   |
+| regular expression   | expressão regular                            |
+| replace              | substituir                                   |
+| report               | reportar                                     |
+| repository           | repositório                                  |
+| require              | requerer\*                                   |
+| return               | retornar                                     |
+| RNG                  | RNG                                          |
+| role                 | papel\*                                      |
+| routine              | rotina                                       |
+| run                  | executar                                     |
+| seal                 | selar                                        |
+| search path          | caminho de busca                             |
+| seed                 | semente                                      |
+| seek                 | buscar                                       |
+| sink                 | sink                                         |
+| slash                | barra                                        |
+| slot                 | slot (termo do R)\*                          |
+| snapshot             | snapshot                                     |
+| socket               | soquete                                      |
+| source               | carregar                                     |
+| splice               | juntar                                       |
+| stack                | stack\*                                      |
+| standardizable       | padronizável                                 |
+| startup              | inicialização                                |
+| strict               | rigoroso(a)                                  |
+| subscript            | índice\*                                     |
+| subset               | dividir em subconjuntos                      |
+| tag                  | etiqueta                                     |
+| tag                  | tag\*                                        |
+| tangling             | tangling\*                                   |
+| tarball              | tarball                                      |
+| template             | modelo\*                                     |
+| thread               | thread\*                                     |
+| timeout              | limite de tempo                              |
+| timer                | cronômetro                                   |
+| timezone             | fuso horário                                 |
+| top level            | nível superior                               |
+| traceback            | traceback                                    |
+| truncate             | truncar                                      |
+| unary operator       | operador unário                              |
+| unbind               | desvincular                                  |
+| underflow            | underflow                                    |
+| unlisted             | não listado                                  |
+| viewport             | viewport                                     |
+| vignette             | vignette                                     |
+| warning              | alerta                                       |
+| workspace            | ambiente de trabalho                         |
+| wrapup               | finalização\*                                |

--- a/web/Conventions_for_Languages/French-specific-translations.qmd
+++ b/web/Conventions_for_Languages/French-specific-translations.qmd
@@ -54,19 +54,24 @@ Dans les cas particuliers, une fonction peut être utilisée comme verbe. Nous a
 L'utilisation des espaces et des paragraphes en français est règlementée par la typographie.
 Les textes R, néanmoins ont des contraintes d'espace et de format qui ne sont pas évidentes à traduire.
 
-Nous plaçons un espace devant les ponctuations telles que :, ;, !, ? (sauf . et ,)
+Nous plaçons un espace devant les ponctuations telles que :  ; ! ? (sauf . et ,)
 
 / : espace avant et après (sauf si c'est un chemin d'accès, par exemple, c:/temp)
 par contre, nous conservons les conventions du langage S pour les guillemets,
 soit '' ou "", mais non transformés et sans espaces.
-’ : remplacer l'apostrophe grasse ’ par l'apostrophe simple '
-` : garder le backtick 
-‘ : remplacer l'apostrophe simple retournée ‘ par l'apostrophe simple '
-“ : remplacer les guillemets doubles retournés ouvrants “ par l'apostrophe simple '
-” : remplacer les guillemets doubles fermants ” par l'apostrophe simple '
+
++ ’ : remplacer l'apostrophe grasse ’ par l'apostrophe simple '
+
++ ` : garder le backtick 
+
++ ‘ : remplacer l'apostrophe simple retournée ‘ par l'apostrophe simple '
+
++ “ : remplacer les guillemets doubles retournés ouvrants “ par l'apostrophe simple '
+
++ ” : remplacer les guillemets doubles fermants ” par l'apostrophe simple '
 
 La plupart des messages R portent sous une certaine forme la référence au code qui les a produits.
-Ceci ce fait à l'aide des [spécifieurs de format](https://cplusplus.com/reference/cstdio/printf/) et ils doivent être dans le même ordre dans le texte de référence.
+Ceci se fait à l'aide des [spécifieurs de format](https://cplusplus.com/reference/cstdio/printf/) et ils doivent être dans le même ordre dans le texte de référence.
 
 > _%s and %s must have the same length_
 
@@ -132,17 +137,19 @@ Nous avons essayé d'utiliser les versions les plus communes de chaque terme, ma
 Par exemple si vous cherchez "_caching_", l'entrée correspondante est "_cache_". 
 Le même mot peut avoir aussi plusieurs fonctions telles que "_replacement_", qui signifie à la fois "substitution" et "substitué".
 
-Certain mots de par leur usage conservent leur terme anglais puisque leur traduction est faiblement utilisée, mais ce n'est que subjectif; les mots affectés d'un astérisque \* sont ceux sur lesquels un consensus doit statuer.
+Certain mots de par leur usage conservent leur terme anglais puisque leur traduction est faiblement utilisée, mais ce n'est que subjectif.
 
 | Anglais              | Français                                     |
 |:---------------------|:---------------------------------------------|
 | aborting             | annulation, abandon                          |
+| alias    | alias   |
 | allocation    | affectation mémoire   |
 | anova    | ANOVA   |
 | argument    | argument (et non paramètre)   |
 | array    | tableau   |
 | assigment    | affectation   |
 | attribute    | attribut   |
+| attach    | joindre, annexer   |
 | backslash    | caractère barre oblique inversée   |
 | binary operator   | opérateur binaire   |
 | bind    | lien (binding : lier)   |
@@ -150,8 +157,8 @@ Certain mots de par leur usage conservent leur terme anglais puisque leur traduc
 | BOM    | BOM (indicateur d'ordre d'octets)   |
 | boxplot    | boîte à moustaches   |
 | breaks    | borne des classes (histogrammes)   |
-| browser    | explorateur   |
-| bytecode    | pseudo-code (code a octets est officiel mais peu utilisé)   |
+| browser    | explorateur, navigateur   |
+| bytecode    | pseudo-code (code à octets est officiel mais peu utilisé)   |
 | cached value    | valeur enregistrée en mémoire cache   |
 | call    | appel   |
 | callback    | rappel (procédure de, callback)   |
@@ -159,50 +166,62 @@ Certain mots de par leur usage conservent leur terme anglais puisque leur traduc
 | categorical    | qualitative (pour une variable)   |
 | channel    | canal   |
 | character    | caractère (sans h)   |
+| check    | vérifier  |
+| chunk    | bloc de code   |
 | clipping    | détourage   |
 | closure    | fermeture (closure)   |
 | cluster    | agrégation, groupe   |
+| codoc   | codoc (fonction de R)   |
 | coerce    | convertir automatiquement   |
 | coercion    | conversion automatique   |
 | collation    | classement   |
-| collapsing level    | niveau de fusion   |
+| collapsing level  | niveau de fusion   |
 | colortype    | colorimétrie   |
-| computationally singular : numériquement singulière (par exemple pour une matrice)   |
+| computationally singular  |  numériquement singulière (par exemple pour une matrice)   |
 | connection   | connexion   |
 | console   | console   |
 | covariate    | covariables   |
-| database    |base de données   |
-| dataframe    | tableau de données, mais on précise (data frame) si nécessaire   |
+| database    | base de données   |
+| dataframe    | tableau de données, mais on précise (data frame) si nécessaire; utilisé au masculin (objet)   |
 | dataset    | jeu de données   |
+| debug  | débogguer   | 
+| defunct | obsolete, n'existe plus  |
 | deparse   | reconstruction de code (deparse)   |
 | deprecated   | obsolète   |
 | deviance    | déviance (en statistique)   |
 | device    | périphérique   |
+| detach | détacher, séparer |
 | dispatch   | dispatcheur   |
+| documentation object| objet de documentation  |
 | double    | ‘double’ (nombre à virgule flottante)   |
 | download   | téléchargement client <- serveur   |
 | driver    | pilote   |
+| drop    | ignorer |
 | edge    | côté (d'un polygone)   |
 | eigenvalues    | valeurs propres   |
 | encoding    | encodage   |
 | environment    | environnement (voir aussi workspace)   |
-| factor    |variable facteur ou facteur   |
+| evaluate    | évaluer, par exemple avec _evaluate()_   |
+| factor    | variable facteur ou facteur   |
 | fallback    | repli (ex: procédure de repli)   |
-| fifo    | fifo (préférable à... peps, peu connu)   |
+| fifo    | fifo , pour _first in, first out_ (préférable à... peps, peu connu)   |
 | filename    | nom de fichier   |
 | file stream    | corps du fichier   |
 | fit    | ajustement ou ajuster   |
+| flag  | balise, baliser, marquer   |
 | flush   | vider ou vidage   |
 | formula    | formule du modèle ou formule tout court   |
 | frame    | cadre ou trame selon le contexte; (data frame : tableau de données)   |
 | GiB    | giga octets (pour les tailles)   |
 | handler    | manipulateur de données (voir aussi interrupt handler)   |
+| hardcoded   | codé en dur |
 | hashing    | hachage   |
 | Hessian    | Hessienne (se dit d'une matrice)   |
 | hinges    | jointures   |
-| history    | historique des commandes   |
+| history    | historique (des commandes)   |
 | image    | image d'environnement (fichier image où les objets R sont sauvés)   |
 | implemented    | implémenté   |
+| incoming checks   | contrôle des entrées  |
 | index    |indice (presque toujours, et non index)   |
 | interrupt handler   | gestionnaire d'interruptions   |
 | invalid    |incorrect (à préférer à 'non valide')   |
@@ -210,42 +229,52 @@ Certain mots de par leur usage conservent leur terme anglais puisque leur traduc
 | issue tracker   | gestionnaire de tickets (issue tracker)   |
 | knots    | noeuds   |
 | kriging    | krigeage   |
-| label    | étiquette   |
+| label    | étiquette, libellé   |
 | lag    | décalage   |
 | l    | en général longueur; compléter avec 'taille' ex: "....différent de la taille l de l'objet DT..."   |
 | layout    | mise en page   |
-| lazy loading    |chargement partiel (explicit loading : chargement complet)   |
-| leading minor   | mineur dominant   |
-| length   | longueur (réserver taille pour size)   |
+| lazy loading    |chargement partiel (_explicit loading_ : chargement complet)   |
+| leading minor   | mineur dominant (sous-matrice)  |
+| length   | longueur (réserver taille pour _size_)   |
 | LHS    | membre gauche (d'une expression, d'une égalité...)   |
 | library    | bibliothèque   |
 | likelihood    |vraisemblance   |
+| link | lien  |
 | list column   | colonne de type liste   |
 | locale    | environnement linguistique   |
 | locator    | mode de localisation à la souris (pour les graphes)   |
 | logical    | booléen   |
 | log-likelihood   | log de vraisemblance   |
+| macro    | macro |
 | magic number   | nombre magique   |
 | map (to map)    |mapper (anglicisme d'usage courant)   |
+| match | correspondance |
 | matrix is exactly singular   | matrice singulière   |
+| metadata    | métadonnées  |
 | metafile    | metafile   |
-| mirror site    | site miroir   |
-| mismatch    |incohérence   |
+| mirror site    | site miroir (_ex_ : CRAN)  |
+| mismatch    | incohérence   |
+| missing | absent  |
 | mixed    | mixte (plutôt que mélangé)   |
 | mode    | mode   |
-| modulus    | modulus   |
+| modulus    | modulo   |
 | multibyte    | multioctets   |
 | NA    | NA ou valeur manquante, selon le contexte   |
 | named args    | arguments nommés   |
 | namespace    | espace de noms   |
 | nondecreasing vector    | vecteur de valeurs non décroissantes   |
+| non-interactively | de façon non interactive |
+| non-numeric type | type non numérique  |
 | non-vector type    | type non vectoriel   |
+| numeric-alike    | numérique ou assimilé   |
 | notches    | indentations   |
+| offending | qui pose problème  |
 | offset    | décalage   |
 | opcode    | code d'opération   |
 | outlier   | valeur extrême   |
 | out of range    | en dehors de l’intervalle   |
-| overflow   |débordement au dépassement de capacité par le haut   |
+| overflow   | débordement ou dépassement de capacité par le haut   |
+| override | réécraser, redéfinir |
 | package    | package (non traduit cf. significations pour paquet ou paquetage)   |
 | pager    | afficheur   |
 | pair list    | liste appairée   |
@@ -269,18 +298,22 @@ Certain mots de par leur usage conservent leur terme anglais puisque leur traduc
 | quote rule    | règle des guillemets   |
 | raw   | raw, si c'est le type de données, sinon brut   |
 | range   | plage, étendue ou intervalle, selon le contexte   |
-| redraw   | retraçage (des affichages), rafraichissement   |
+| redraw   | retraçage (des affichages), rafraîchissement   |
 | regex   | expression régulière   |
 | regular expression   | expression régulière   |
-| report   |(to report : signaler)   |
+| replace | substituer |
+| report   | (to report : signaler)   |
 | repository   | entrepôt, dépôt   |
+| required    | nécessaire  |
 | residuals    | résidus   |
 | restore   | restaurer   |
 | return   | retourner (abcd -> dcba) ou renvoyer (d'une fonction) selon le contexte   |
 | RHS    | membre droit (d'une expression, d'une égalité...)   |
 | RNG   | RNG ou générateur de nombres pseudo-aléatoires   |
 | routine   | sous-programme ou procédure   |
+| run   | exécuter (une fonction, un script...)  |
 | scaled    | standardisé, mis à l'échelle   |
+| seal    | sceller   |
 | search path    | chemin de recherche   |
 | seed    | valeurs d'initialisation d'un processus, graine aléatoire (ex: génération des nombres aléatoires)   |
 | seek    | mode d'accès aléatoire   |
@@ -291,20 +324,24 @@ Certain mots de par leur usage conservent leur terme anglais puisque leur traduc
 | size    | taille   |
 | skew-symmetric   | matrice anti-symétrique   |
 | slash    | caractère barre oblique droite '/' (opposé à antislash barre oblique gauche '\')   |
-| slot    | slot (sous partie d'un objet S4, terme spécifique de S)   |
+| slot    | slot (sous partie d'un objet S4, terme spécifique du _S_)   |
 | snapshot    | instantané graphique, capture d'écran   |
 | socket   | connecteur logiciel (ou socket -usage courant- dans les longs messages)   |
 | source    | source (to source : sourcer, préférable à entrée par défaut)   |
 | specified    | fourni (voir choisi ou donné, selon le contexte)   |
+| splice   | joindre  |
 | stack   | pile   |
 | standard deviation   | écart-type   |
+| startup | démarrage, initialisation  |
 | stratum    |strate   |
 | subscript    | indice   |
 | subset    | sous-ensemble (subsetting : indiçage, ou réalisation d'un sous-ensemble)   |
 | supernode    |super-noeud   |
 | supported   | pris en charge (pas supporté, qui est un anglicisme)   |
 | table    | tableau de contingence   |
-| tag    | marque   |
+| tag    | marque, balise   |
+| tarball | archive, tarball  |
+| template | modèle  |
 | thermometer    | jauge (contexte de graphes)   |
 | thread    | contexte (threaded code : code contextuel)   |
 | thread buffers        |  mémoire tampon des thread   |
@@ -321,6 +358,7 @@ Certain mots de par leur usage conservent leur terme anglais puisque leur traduc
 | unary operator       |  opérateur unaire   |
 | unbind       |  délier   |
 | underflow       |  dépassement de capacité par le bas   |
+| unlisted  | non listé |
 | unmatched       |  déparié   |
 | unpacking        |  extraction   |
 | unwrap columns        |  déplier les colonnes   |
@@ -334,174 +372,5 @@ Certain mots de par leur usage conservent leur terme anglais puisque leur traduc
 | warning       |  avis (avertissement est bien aussi, mais trop long)   |
 | weight        |  pondération   |
 | working directory        |  répertoire de travail   |
-| workspace       | environnement de travail (workspace = environment dans R)   |
-ou session s'il s'agit à la fois de l'historique et de l'environnement   |
+| workspace       | environnement de travail (workspace = environment dans R) ou session s'il s'agit à la fois de l'historique et de l'environnement   |
 | wrapup       | emballer ou emballage   |
-
-
-
-| Inglês               | Português                                    |
-|:---------------------|:---------------------------------------------|
-| abort                | interromper                                  |
-| alias                | alias\*                                      |
-| allocate             | alocar                                       |
-| argument             | argumento                                    |
-| array                | array                                        |
-| assign               | atribuir                                     |
-| attach               | anexar                                       |
-| attribute            | atributo                                     |
-| backslash            | barra invertida                              |
-| bind                 | associar / vincular                          |
-| bitmap               | bitmap                                       |
-| boxplot              | boxplot                                      |
-| break                | limite de categoria (para histogramas)       |
-| browser              | navegador                                    |
-| build                | compilar                                     |
-| bytecode             | bytecode                                     |
-| cache                | cachear                                      |
-| call                 | chamar                                       |
-| callback             | callback                                     |
-| character string     | string de caracteres\*                       |
-| check                | verificar                                    |
-| chunk                | bloco (de código)\*                          |
-| closure              | closure                                      |
-| codoc                | codoc (da função do R)                       |
-| coerce               | fazer coerção                                |
-| colortype            | colortype                                    |
-| console              | console                                      |
-| data frame           | data frame                                   |
-| database             | base de dados                                |
-| dataset              | conjunto de dados                            |
-| debug                | depurar\*                                    |
-| defunct              | extinto                                      |
-| deparse              | deparse                                      |
-| deprecated           | obsoleto                                     |
-| detach               | detach\*                                     |
-| device               | dispositivo                                  |
-| dispatch             | despachar                                    |
-| documentation object | objeto de documentação\*                     |
-| download             | baixar                                       |
-| driver               | driver                                       |
-| drop                 | descartar                                    |
-| encoding             | codificação                                  |
-| entry                | registro / campo                             |
-| environment          | ambiente                                     |
-| evaluate             | avaliar (por exemplo, `eval()`)\*            |
-| factor               | fator                                        |
-| fifo                 | fifo (de _first in, first out_)              |
-| file pointer         | ponteiro de arquivo\*                        |
-| file stream          | stream de arquivo                            |
-| filename             | nome do arquivo                              |
-| fit                  | ajustar                                      |
-| flag                 | flag                                         |
-| flush                | esvaziar                                     |
-| frame                | quadro (para _stack_) / escopo (para _call_) |
-| handle               | gerenciar                                    |
-| hard-coded           | hard-coded\*                                 |
-| history              | histórico                                    |
-| implement            | implementar                                  |
-| incoming checks      | verificações de recebimento\*                |
-| index                | índice                                       |
-| invalid              | inválido                                     |
-| IO                   | IO                                           |
-| label                | rótulo                                       |
-| lag                  | defasagem                                    |
-| layout               | layout\*                                     |
-| lazy loading         | lazy loading\*                               |
-| lazydata             | lazydata                                     |
-| leading minor        | submatriz\*                                  |
-| length               | comprimento                                  |
-| library              | biblioteca                                   |
-| link                 | link                                         |
-| locale               | locale                                       |
-| locator              | localizador                                  |
-| locking              | travamento\*                                 |
-| logical              | lógico (ao invés de booleano)                |
-| macro                | macro                                        |
-| magic number         | número mágico                                |
-| match                | corresponder                                 |
-| metafile             | metafile                                     |
-| mirror               | espelho (por exemplo, do CRAN)               |
-| mismatch             | incompatível                                 |
-| missing              | ausente                                      |
-| modulus              | módulo                                       |
-| multibyte            | multibyte                                    |
-| namespace            | namespace\*                                  |
-| non-interactively    | de forma não interativa                      |
-| non-numeric type     | tipo não numérico                            |
-| numeric-alike        | numérico ou similar\*                        |
-| offending            | problemático                                 |
-| offset               | deslocar / compensar (depende do contexto)   |
-| opcode               | opcode                                       |
-| outlier              | outlier\*                                    |
-| overflow             | overflow                                     |
-| override             | sobrescrever                                 |
-| package              | pacote                                       |
-| pager                | visualizador\*                               |
-| pair list            | lista pareada                                |
-| parse                | analisar\*                                   |
-| path                 | caminho                                      |
-| pipe                 | pipe                                         |
-| pixmap               | pixmap                                       |
-| platform             | plataforma                                   |
-| polyline             | polyline                                     |
-| port                 | porta (por exemplo, 8080)                    |
-| portable             | portável                                     |
-| profiling            | análise de desempenho                        |
-| profile              | perfil (substantivo), perfilar (verbo)       |
-| promise              | promessa                                     |
-| prompt               | prompt                                       |
-| proxy                | proxy                                        |
-| push back            | voltar atrás                                 |
-| quote symbol         | símbolo de citação                           |
-| range                | intervalo / limite (depende do contexto)     |
-| raw                  | raw (para o tipo de dado)                    |
-| redraw               | redesenhar                                   |
-| regular expression   | expressão regular                            |
-| replace              | substituir                                   |
-| report               | reportar                                     |
-| repository           | repositório                                  |
-| require              | requerer\*                                   |
-| return               | retornar                                     |
-| RNG                  | RNG                                          |
-| role                 | papel\*                                      |
-| routine              | rotina                                       |
-| run                  | executar                                     |
-| seal                 | selar                                        |
-| search path          | caminho de busca                             |
-| seed                 | semente                                      |
-| seek                 | buscar                                       |
-| sink                 | sink                                         |
-| slash                | barra                                        |
-| slot                 | slot (termo do R)\*                          |
-| snapshot             | snapshot                                     |
-| socket               | soquete                                      |
-| source               | carregar                                     |
-| splice               | juntar                                       |
-| stack                | stack\*                                      |
-| standardizable       | padronizável                                 |
-| startup              | inicialização                                |
-| strict               | rigoroso(a)                                  |
-| subscript            | índice\*                                     |
-| subset               | dividir em subconjuntos                      |
-| tag                  | etiqueta                                     |
-| tag                  | tag\*                                        |
-| tangling             | tangling\*                                   |
-| tarball              | tarball                                      |
-| template             | modelo\*                                     |
-| thread               | thread\*                                     |
-| timeout              | limite de tempo                              |
-| timer                | cronômetro                                   |
-| timezone             | fuso horário                                 |
-| top level            | nível superior                               |
-| traceback            | traceback                                    |
-| truncate             | truncar                                      |
-| unary operator       | operador unário                              |
-| unbind               | desvincular                                  |
-| underflow            | underflow                                    |
-| unlisted             | não listado                                  |
-| viewport             | viewport                                     |
-| vignette             | vignette                                     |
-| warning              | alerta                                       |
-| workspace            | ambiente de trabalho                         |
-| wrapup               | finalização\*                                |

--- a/web/Conventions_for_Languages/French-specific-translations.qmd
+++ b/web/Conventions_for_Languages/French-specific-translations.qmd
@@ -54,6 +54,17 @@ Dans les cas particuliers, une fonction peut être utilisée comme verbe. Nous a
 L'utilisation des espaces et des paragraphes en français est règlementée par la typographie.
 Les textes R, néanmoins ont des contraintes d'espace et de format qui ne sont pas évidentes à traduire.
 
+Nous plaçons un espace devant les ponctuations telles que :, ;, !, ? (sauf . et ,)
+
+/ : espace avant et après (sauf si c'est un chemin d'accès, par exemple, c:/temp)
+par contre, nous conservons les conventions du langage S pour les guillemets,
+soit '' ou "", mais non transformés et sans espaces.
+’ : remplacer l'apostrophe grasse ’ par l'apostrophe simple '
+` : garder le backtick 
+‘ : remplacer l'apostrophe simple retournée ‘ par l'apostrophe simple '
+“ : remplacer les guillemets doubles retournés ouvrants “ par l'apostrophe simple '
+” : remplacer les guillemets doubles fermants ” par l'apostrophe simple '
+
 La plupart des messages R portent sous une certaine forme la référence au code qui les a produits.
 Ceci ce fait à l'aide des [spécifieurs de format](https://cplusplus.com/reference/cstdio/printf/) et ils doivent être dans le même ordre dans le texte de référence.
 
@@ -122,6 +133,212 @@ Par exemple si vous cherchez "_caching_", l'entrée correspondante est "_cache_"
 Le même mot peut avoir aussi plusieurs fonctions telles que "_replacement_", qui signifie à la fois "substitution" et "substitué".
 
 Certain mots de par leur usage conservent leur terme anglais puisque leur traduction est faiblement utilisée, mais ce n'est que subjectif; les mots affectés d'un astérisque \* sont ceux sur lesquels un consensus doit statuer.
+
+| Anglais              | Français                                     |
+|:---------------------|:---------------------------------------------|
+| aborting             | annulation, abandon                          |
+| allocation    | affectation mémoire   |
+| anova    | ANOVA   |
+| argument    | argument (et non paramètre)   |
+| array    | tableau   |
+| assigment    | affectation   |
+| attribute    | attribut   |
+| backslash    | caractère barre oblique inversée   |
+| binary operator   | opérateur binaire   |
+| bind    | lien (binding : lier)   |
+| bitmap    | bitmap   |
+| BOM    | BOM (indicateur d'ordre d'octets)   |
+| boxplot    | boîte à moustaches   |
+| breaks    | borne des classes (histogrammes)   |
+| browser    | explorateur   |
+| bytecode    | pseudo-code (code a octets est officiel mais peu utilisé)   |
+| cached value    | valeur enregistrée en mémoire cache   |
+| call    | appel   |
+| callback    | rappel (procédure de, callback)   |
+| case insensitive matching    | correspondance insensible à la casse   |
+| categorical    | qualitative (pour une variable)   |
+| channel    | canal   |
+| character    | caractère (sans h)   |
+| clipping    | détourage   |
+| closure    | fermeture (closure)   |
+| cluster    | agrégation, groupe   |
+| coerce    | convertir automatiquement   |
+| coercion    | conversion automatique   |
+| collation    | classement   |
+| collapsing level    | niveau de fusion   |
+| colortype    | colorimétrie   |
+| computationally singular : numériquement singulière (par exemple pour une matrice)   |
+| connection   | connexion   |
+| console   | console   |
+| covariate    | covariables   |
+| database    |base de données   |
+| dataframe    | tableau de données, mais on précise (data frame) si nécessaire   |
+| dataset    | jeu de données   |
+| deparse   | reconstruction de code (deparse)   |
+| deprecated   | obsolète   |
+| deviance    | déviance (en statistique)   |
+| device    | périphérique   |
+| dispatch   | dispatcheur   |
+| double    | ‘double’ (nombre à virgule flottante)   |
+| download   | téléchargement client <- serveur   |
+| driver    | pilote   |
+| edge    | côté (d'un polygone)   |
+| eigenvalues    | valeurs propres   |
+| encoding    | encodage   |
+| environment    | environnement (voir aussi workspace)   |
+| factor    |variable facteur ou facteur   |
+| fallback    | repli (ex: procédure de repli)   |
+| fifo    | fifo (préférable à... peps, peu connu)   |
+| filename    | nom de fichier   |
+| file stream    | corps du fichier   |
+| fit    | ajustement ou ajuster   |
+| flush   | vider ou vidage   |
+| formula    | formule du modèle ou formule tout court   |
+| frame    | cadre ou trame selon le contexte; (data frame : tableau de données)   |
+| GiB    | giga octets (pour les tailles)   |
+| handler    | manipulateur de données (voir aussi interrupt handler)   |
+| hashing    | hachage   |
+| Hessian    | Hessienne (se dit d'une matrice)   |
+| hinges    | jointures   |
+| history    | historique des commandes   |
+| image    | image d'environnement (fichier image où les objets R sont sauvés)   |
+| implemented    | implémenté   |
+| index    |indice (presque toujours, et non index)   |
+| interrupt handler   | gestionnaire d'interruptions   |
+| invalid    |incorrect (à préférer à 'non valide')   |
+| IO    | E/S (pour entrées/sorties)   |
+| issue tracker   | gestionnaire de tickets (issue tracker)   |
+| knots    | noeuds   |
+| kriging    | krigeage   |
+| label    | étiquette   |
+| lag    | décalage   |
+| l    | en général longueur; compléter avec 'taille' ex: "....différent de la taille l de l'objet DT..."   |
+| layout    | mise en page   |
+| lazy loading    |chargement partiel (explicit loading : chargement complet)   |
+| leading minor   | mineur dominant   |
+| length   | longueur (réserver taille pour size)   |
+| LHS    | membre gauche (d'une expression, d'une égalité...)   |
+| library    | bibliothèque   |
+| likelihood    |vraisemblance   |
+| list column   | colonne de type liste   |
+| locale    | environnement linguistique   |
+| locator    | mode de localisation à la souris (pour les graphes)   |
+| logical    | booléen   |
+| log-likelihood   | log de vraisemblance   |
+| magic number   | nombre magique   |
+| map (to map)    |mapper (anglicisme d'usage courant)   |
+| matrix is exactly singular   | matrice singulière   |
+| metafile    | metafile   |
+| mirror site    | site miroir   |
+| mismatch    |incohérence   |
+| mixed    | mixte (plutôt que mélangé)   |
+| mode    | mode   |
+| modulus    | modulus   |
+| multibyte    | multioctets   |
+| NA    | NA ou valeur manquante, selon le contexte   |
+| named args    | arguments nommés   |
+| namespace    | espace de noms   |
+| nondecreasing vector    | vecteur de valeurs non décroissantes   |
+| non-vector type    | type non vectoriel   |
+| notches    | indentations   |
+| offset    | décalage   |
+| opcode    | code d'opération   |
+| outlier   | valeur extrême   |
+| out of range    | en dehors de l’intervalle   |
+| overflow   |débordement au dépassement de capacité par le haut   |
+| package    | package (non traduit cf. significations pour paquet ou paquetage)   |
+| pager    | afficheur   |
+| pair list    | liste appairée   |
+| parse    | analyse syntaxique du code (to parse : analyser le code)   |
+| parser    | analyseur syntaxique   |
+| passed    | transmis   |
+| passed in    | passé en argument   |
+| path    | chemin d'accès (d'un fichier...)   |
+| pattern    | motif   |
+| pipe    | conduite, caractère barre verticale '|'    |
+| pixmap    | pixmap (format de fichier image)   |
+| platform    | architecture   |
+| polyline   | ligne brisée   |
+| port    | port (sur un serveur TCP/IP par exemple)   |
+| profiling    | profilage (to profile : profiler)   |
+| promise   | promesse (promise)   |
+| prompt    | invite ou invite de commande   |
+| proxy    | proxy   |
+| push back    | repoussage   |   
+| quote symbol   | symbole de chaîne de caractères (et non de citation)   |
+| quote rule    | règle des guillemets   |
+| raw   | raw, si c'est le type de données, sinon brut   |
+| range   | plage, étendue ou intervalle, selon le contexte   |
+| redraw   | retraçage (des affichages), rafraichissement   |
+| regex   | expression régulière   |
+| regular expression   | expression régulière   |
+| report   |(to report : signaler)   |
+| repository   | entrepôt, dépôt   |
+| residuals    | résidus   |
+| restore   | restaurer   |
+| return   | retourner (abcd -> dcba) ou renvoyer (d'une fonction) selon le contexte   |
+| RHS    | membre droit (d'une expression, d'une égalité...)   |
+| RNG   | RNG ou générateur de nombres pseudo-aléatoires   |
+| routine   | sous-programme ou procédure   |
+| scaled    | standardisé, mis à l'échelle   |
+| search path    | chemin de recherche   |
+| seed    | valeurs d'initialisation d'un processus, graine aléatoire (ex: génération des nombres aléatoires)   |
+| seek    | mode d'accès aléatoire   |
+| self-starting function   | fonction auto-initialisée   |
+| sequence    | suite (selon contexte) ou séquence   |
+| shingle   |latte (dans lattice)   |
+| sink    | sortie par défaut   |
+| size    | taille   |
+| skew-symmetric   | matrice anti-symétrique   |
+| slash    | caractère barre oblique droite '/' (opposé à antislash barre oblique gauche '\')   |
+| slot    | slot (sous partie d'un objet S4, terme spécifique de S)   |
+| snapshot    | instantané graphique, capture d'écran   |
+| socket   | connecteur logiciel (ou socket -usage courant- dans les longs messages)   |
+| source    | source (to source : sourcer, préférable à entrée par défaut)   |
+| specified    | fourni (voir choisi ou donné, selon le contexte)   |
+| stack   | pile   |
+| standard deviation   | écart-type   |
+| stratum    |strate   |
+| subscript    | indice   |
+| subset    | sous-ensemble (subsetting : indiçage, ou réalisation d'un sous-ensemble)   |
+| supernode    |super-noeud   |
+| supported   | pris en charge (pas supporté, qui est un anglicisme)   |
+| table    | tableau de contingence   |
+| tag    | marque   |
+| thermometer    | jauge (contexte de graphes)   |
+| thread    | contexte (threaded code : code contextuel)   |
+| thread buffers        |  mémoire tampon des thread   |
+| timeout        |  délai maximal   |
+| timer       |  horloge ou temporisation, selon le contexte   |
+| timezone        |  fuseau horaire   |
+| tl        |  en général taille préallouée (pour true length) ; Compléter avec le texte ex: "...différent de la taille préallouée tl de l'objet DT..."   |
+| top level        |  niveau le plus haut   |
+| traceback        |  historique des fonctions appelées ('traceback')   |
+| trimmed mean       |  moyenne tronquée   |
+| truncation       |  troncature   |
+| type       |  type   |
+| type bumps        |  collision / changement de type   |
+| unary operator       |  opérateur unaire   |
+| unbind       |  délier   |
+| underflow       |  dépassement de capacité par le bas   |
+| unmatched       |  déparié   |
+| unpacking        |  extraction   |
+| unwrap columns        |  déplier les colonnes   |
+| unmapping view of file       |  annulation du mappage / démappage de la vue du fichier   |
+| upload       |  téléversement client -> serveur   |
+| url        | URL   |
+| unsupported        |  non pris en charge   |
+| vertex        |  sommet (d'un polygone)   |
+| viewport       |  vue   |
+| vignette        |  vignette   |
+| warning       |  avis (avertissement est bien aussi, mais trop long)   |
+| weight        |  pondération   |
+| working directory        |  répertoire de travail   |
+| workspace       | environnement de travail (workspace = environment dans R)   |
+ou session s'il s'agit à la fois de l'historique et de l'environnement   |
+| wrapup       | emballer ou emballage   |
+
+
 
 | Inglês               | Português                                    |
 |:---------------------|:---------------------------------------------|

--- a/web/Conventions_for_Languages/French-specific-translations.qmd
+++ b/web/Conventions_for_Languages/French-specific-translations.qmd
@@ -18,11 +18,11 @@ Pour aider le processus de traduction, veuillez :
 
 1. Vous inscrire au [Slack des contributeurs de R](https://contributor.r-project.org/slack) et présentez-vous sur le canal 
 `#core-translations`
-1. Lire la section [Ressources](#resources) de ce document, car la traduction suit certaines conventions à respecter
+1. Lire la section [Ressources](#Ressources) de ce document, car la traduction suit certaines conventions à respecter
 1. Créer un compte sur [Weblate](https://translate.rx.studio/) (maintenu actuellement par [@daroczig](https://twitter.com/daroczig))
 1. Lister chaque [composant](https://translate.rx.studio/languages/fr/r-project/) en français
 1. Choisir un composant qui n'est pas traduit à 100% (comme par exemple le [package utils](https://translate.rx.studio/projects/r-project/utils-r/fr/))
-1. Cliquer sur **Unfinished strings** pour lister tous les messages non traduits et
+1. Cliquer sur **Chaînes non terminées** pour lister tous les messages non traduits et
 1. Commencez !
 
 ## Style

--- a/web/Conventions_for_Languages/index.qmd
+++ b/web/Conventions_for_Languages/index.qmd
@@ -116,6 +116,7 @@ _Process to be defined_
 |[Brazilian-Portugese](Brazilian‐Portugese-specific-translations.qmd)| [Caio Lente](https://github.com/clente), [Renata Hirota](https://github.com/rmhirota)|
 |[Catalan](Catalan-specific-translations.qmd)| [Joan Maspons](https://github.com/jmaspons), [Robert Castelo](https://github.com/rcastelo)|
 |[Chinese 中文](Chinese-specific-translations.qmd)|[Shun Wang](https://github.com/shun2wang)|
+|[French](French-specific-translations.qmd)| [Christian Wiat](https://github.com/ChristianWia) |
 |[Hindi](Hindi-specific-translations.qmd)| [Saranjeet Kaur Bhogal](https://github.com/SaranjeetKaur), [Ayush Patel](https://github.com/AyushBipinPatel)  |
 |[Japanese](Japanese-specific-translations.qmd)| [Reiko Okamoto](https://github.com/reikookamoto) |
 |[Nepali](Nepali-specific-translations.qmd)| [Binod Jung Bogati](https://github.com/bjungbogati) |

--- a/web/index.qmd
+++ b/web/index.qmd
@@ -30,7 +30,6 @@ exist yet, please feel free to submit a pull request and create it.
     | -- |
     |[Arabic](Conventions_for_Languages/Arabic-specific-translations.qmd) |
     |[Bengali](Conventions_for_Languages/Bengali-specific-translations.qmd)|
-    |[Brazilian-Portugese](Conventions_for_Languages/Brazilian‐Portugese-specific-translations.qmd)|
     |[Catalan](Conventions_for_Languages/Catalan-specific-translations.qmd)|
     |[Chinese](Conventions_for_Languages/Chinese-specific-translations.qmd)|
     |[French](Conventions_for_Languages/French-specific-translations.qmd)|

--- a/web/index.qmd
+++ b/web/index.qmd
@@ -30,8 +30,10 @@ exist yet, please feel free to submit a pull request and create it.
     | -- |
     |[Arabic](Conventions_for_Languages/Arabic-specific-translations.qmd) |
     |[Bengali](Conventions_for_Languages/Bengali-specific-translations.qmd)|
+    |[Brazilian-Portugese](Conventions_for_Languages/Brazilian‐Portugese-specific-translations.qmd)|
     |[Catalan](Conventions_for_Languages/Catalan-specific-translations.qmd)|
     |[Chinese](Conventions_for_Languages/Chinese-specific-translations.qmd)|
+    |[French](Conventions_for_Languages/French-specific-translations.qmd)|
     |[Hindi](Conventions_for_Languages/Hindi-specific-translations.qmd)|
     |[Nepali](Conventions_for_Languages/Nepali-specific-translations.qmd)|
     |[Portuguese (Brazilian)](Conventions_for_Languages/Brazilian‐Portugese-specific-translations.qmd)|


### PR DESCRIPTION
create the file (based on portuguese structure)
bring the glossary from internal dico of  FR team (@phgrosjean)
declare the FR entry points in index.qmd pages
adapt entry points  and minor corrections to view  Brazilian-Portugese (Brazilian‐Portugese-specific-translations.qmd)
make a global site rendering in Rstudio with 
> quarto_preview_stop()
> quarto_preview("web")

> E:\git\translations\web>quarto render
[ 1/14] Conventions_for_Languages\Arabic-specific-translations.qmd
[ 2/14] Conventions_for_Languages\Bengali-specific-translations.qmd
[ 3/14] Conventions_for_Languages\Brazilian‐Portugese-specific-translations.qmd
[ 4/14] Conventions_for_Languages\Catalan-specific-translations.qmd
[ 5/14] Conventions_for_Languages\Chinese-specific-translations.qmd
[ 6/14] Conventions_for_Languages\French-specific-translations.qmd
[ 7/14] Conventions_for_Languages\Hindi-specific-translations.qmd
[ 8/14] Conventions_for_Languages\Japanese-specific-translations.qmd
[ 9/14] Conventions_for_Languages\Nepali-specific-translations.qmd
[10/14] Conventions_for_Languages\Spanish-specific-translations.qmd
[11/14] Conventions_for_Languages\index.qmd
[12/14] Weblate-FAQ.qmd
[13/14] Weblate-server.qmd
[14/14] index.qmd

Output created: _site\index.html

E:\git\translations\web>

verified browsing is OK in FR and Brz-POrt pages  with ->   E:\git\translations\web\ _site\index.html